### PR TITLE
Add migration from Scales to pufferd

### DIFF
--- a/data/templates/srcds.go
+++ b/data/templates/srcds.go
@@ -57,7 +57,7 @@ const SRCDS = `{
         "display": "Application ID",
         "internal": false
       },
-        "gametype": {
+      "gametype": {
         "value": "tf",
         "required": true,
         "desc": "Game Type",
@@ -120,7 +120,7 @@ const TF2 = `{
         "+map ${map}",
       	"-norestart"
       ],
-      "program": "./srcds_run"
+      "program": "./srcds_run +ip ${ip} +port ${port}"
     },
     "environment": {
       "type": "tty"

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"github.com/pufferpanel/pufferd/utils"
 	"os"
+	"github.com/pufferpanel/pufferd/programs"
 )
 
 const Scales = "/srv/scales/data"
@@ -48,6 +49,13 @@ func MigrateFromScales() {
 			logging.Error("Error changing owner of folder", err);
 			continue
 		}
+		serverData := make(map[string]interface{})
+		serverData["ip"] = scales.Gamehost
+		serverData["port"] = scales.Gameport
+		if scales.Plugin == "minecraft" {
+			serverData["memory"] = scales.Build.Memory
+		}
+		programs.Create(scales.Name, scales.Plugin, serverData)
 	}
 }
 

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -54,6 +54,10 @@ func MigrateFromScales() {
 		serverData["port"] = scales.Gameport
 		if scales.Plugin == "minecraft" {
 			serverData["memory"] = scales.Build.Memory
+		} else if scales.Plugin == "srcds" {
+			serverData["appid"] = scales.Startup.Variables.Build_Params
+			serverData["gametype"] = scales.Startup.Variables.Game
+			serverData["map"] = scales.Startup.Variables.Map
 		}
 		programs.Create(scales.Name, scales.Plugin, serverData)
 	}
@@ -66,6 +70,7 @@ type scalesServer struct {
 	Gameport int               `json:"gameport,omitempty"`
 	Gamehost string            `json:"gamehost,omitempty"`
 	Plugin   string            `json:"plugin,omitempty"`
+	Startup  scalesServerStartup `json:"startup,omitempty"`
 }
 
 type scalesServerBuild struct {
@@ -78,4 +83,7 @@ type scalesServerStartup struct {
 
 type scalesServerStartupVariables struct {
 	Build_Params string `json:"build_params,omitempty"`
+	Game         string `json:"game,omitempty"`
+	Map          string `json:"map,omitempty"`
+	Players      string `json:"players,omitempty"`
 }

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -10,12 +10,14 @@ import (
 	"github.com/pufferpanel/pufferd/utils"
 	"os"
 	"github.com/pufferpanel/pufferd/programs"
+	"github.com/pufferpanel/pufferd/data/templates"
 )
 
 const Scales = "/srv/scales/data"
 
 func MigrateFromScales() {
-	wd, err := os.Getwd()
+	templates.CopyTemplates()
+
 	programFiles, err := ioutil.ReadDir(Scales)
 	if err != nil {
 		logging.Critical("Error reading from old Scales folder", err)
@@ -38,7 +40,7 @@ func MigrateFromScales() {
 			logging.Error("Error read server config " + id, err)
 			continue
 		}
-		newPath := utils.JoinPath(wd, "data", "servers", scales.Name)
+		newPath := utils.JoinPath("data", "servers", scales.Name)
 		err = os.Rename(utils.JoinPath("/home", scales.User), newPath)
 		if err != nil {
 			logging.Error("Error moving folder", err);

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -1,0 +1,73 @@
+package migration
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+
+	"github.com/pufferpanel/pufferd/logging"
+	"encoding/json"
+	"github.com/pufferpanel/pufferd/utils"
+	"os"
+)
+
+const Scales = "/srv/scales/data"
+
+func MigrateFromScales() {
+	wd, err := os.Getwd()
+	programFiles, err := ioutil.ReadDir(Scales)
+	if err != nil {
+		logging.Critical("Error reading from old Scales folder", err)
+		return
+	}
+	for _, element := range programFiles {
+		if element.IsDir() {
+			continue
+		}
+		id := strings.TrimSuffix(element.Name(), filepath.Ext(element.Name()))
+		logging.Infof("Attempting to migrate %s", id)
+		data, err := ioutil.ReadAll(utils.JoinPath(Scales, element))
+		if err != nil {
+			logging.Error("Error read server config " + id, err)
+			continue
+		}
+		scales := scalesServer{}
+		err = json.Unmarshal(data, &scales)
+		if err != nil {
+			logging.Error("Error read server config " + id, err)
+			continue
+		}
+		newPath := utils.JoinPath(wd, "data", "servers", scales.Name)
+		err = os.Rename(utils.JoinPath("/home", scales.User), newPath)
+		if err != nil {
+			logging.Error("Error moving folder", err);
+			continue
+		}
+		err = os.Chown(newPath, os.Getuid(), os.Getgid())
+		if err != nil {
+			logging.Error("Error changing owner of folder", err);
+			continue
+		}
+	}
+}
+
+type scalesServer struct {
+	Name     string            `json:"name,omitempty"`
+	User     string            `json:"user,omitempty"`
+	Build    scalesServerBuild `json:"build,omitempty"`
+	Gameport int               `json:"gameport,omitempty"`
+	Gamehost string            `json:"gamehost,omitempty"`
+	Plugin   string            `json:"plugin,omitempty"`
+}
+
+type scalesServerBuild struct {
+	Memory string `json:"memory,omitempty"`
+}
+
+type scalesServerStartup struct {
+	Variables scalesServerStartupVariables `json:"variables,omitempty"`
+}
+
+type scalesServerStartupVariables struct {
+	Build_Params string `json:"build_params,omitempty"`
+}

--- a/pufferd.go
+++ b/pufferd.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pufferpanel/pufferd/data"
 	"github.com/pufferpanel/pufferd/data/templates"
 	"github.com/pufferpanel/pufferd/logging"
+	"github.com/pufferpanel/pufferd/migration"
 	"github.com/pufferpanel/pufferd/programs"
 	"github.com/pufferpanel/pufferd/routing"
 	"github.com/pufferpanel/pufferd/routing/server"
@@ -54,6 +55,7 @@ func main() {
 	var install bool
 	var version bool
 	var license bool
+	var migrate bool
 	flag.StringVar(&loggingLevel, "logging", "INFO", "Lowest logging level to display")
 	flag.IntVar(&port, "port", 5656, "Port to run service on")
 	flag.StringVar(&authRoot, "auth", "", "Base URL to the authorization server")
@@ -61,6 +63,7 @@ func main() {
 	flag.BoolVar(&install, "install", false, "If installing instead of running")
 	flag.BoolVar(&version, "version", false, "Get the version")
 	flag.BoolVar(&license, "license", false, "View license")
+	flag.BoolVar(&migrate, "migrate", false, "Migrate Scales data to pufferd")
 	flag.Parse()
 
 	versionString := fmt.Sprintf("pufferd %s (%s %s)", MAJORVERSION, BUILDDATE, GITHASH)
@@ -73,7 +76,11 @@ func main() {
 		os.Stdout.WriteString(data.LICENSE + "\r\n")
 	}
 
-	if license || version {
+	if migrate {
+		migration.MigrateFromScales()
+	}
+
+	if license || version || migrate {
 		return
 	}
 


### PR DESCRIPTION
This will migrate the data and files from Scales to pufferd.

This will not completely clean up Scales however. The system users and such will remain on the system, we simply move the actual server files and create the new configs.