### PR TITLE
Fixed backwards logic

### DIFF
--- a/routing/server/server.go
+++ b/routing/server/server.go
@@ -123,7 +123,6 @@ func KillServer(c *gin.Context) {
 	item, _ := c.Get("server")
 	server := item.(programs.Program)
 
-
 	err := server.Kill()
 	if err != nil {
 		errorConnection(c, err)
@@ -137,7 +136,7 @@ func CreateServer(c *gin.Context) {
 	serverId := c.Param("id")
 	prg, _ := programs.Get(serverId)
 
-	if prg != nil{
+	if prg != nil {
 		http.Respond(c).Code(409).Message("server already exists").Send()
 		return
 	}
@@ -300,10 +299,10 @@ func PutFile(c *gin.Context) {
 	var sourceFile io.ReadCloser
 
 	if noform {
+		sourceFile = c.Request.Body
+	} else {
 		c.Request.ParseMultipartForm(32 << 20)
 		sourceFile, _, err = c.Request.FormFile("file")
-	} else {
-		sourceFile = c.Request.Body
 	}
 
 	_, err = io.Copy(file, sourceFile)


### PR DESCRIPTION
If the 'noform' query parameter does not exist, then FormFile must be
used because the upload will be a multipart form.  When 'noform' is set,
the uploaded file is plain text in the body of the request and can be
simply copied out to the local file.  Prior to this commit, if 'noform'
was absent from the query, then the multipart form was copied (in
encoded form) to the file.