### PR TITLE
add support for `run pre operations`

### DIFF
--- a/programs/program.go
+++ b/programs/program.go
@@ -119,9 +119,17 @@ func (p *ProgramData) Stop() (err error) {
 	err = p.Environment.ExecuteInMainProcess(p.RunData.Stop)
 	if err != nil {
 		p.Environment.DisplayToConsole("Failed to stop server\n")
-	} else {
-		p.Environment.DisplayToConsole("Server stopped\n")
+		return
 	}
+	
+	// wait for 120 seconds while server stops
+	err = p.Environment.WaitForMainProcessFor(120)
+	if err != nil {
+		logging.Error("Error stopping server", err)
+		return
+	}
+	
+	p.Environment.DisplayToConsole("Server stopped\n")
 	
 	process := operations.GenerateProcess(p.RunData.Post, p.Environment, p.DataToMap())
 	err = process.Run()

--- a/programs/program.go
+++ b/programs/program.go
@@ -99,6 +99,7 @@ func (p *ProgramData) Start() (err error) {
 	err = process.Run()
 	if err != nil {
 		p.Environment.DisplayToConsole("Error running pre execute, check daemon logs")
+		return
 	}
 	
 	err = p.Environment.ExecuteAsync(p.RunData.Program, common.ReplaceTokensInArr(p.RunData.Arguments, data), func(graceful bool) {
@@ -126,6 +127,7 @@ func (p *ProgramData) Stop() (err error) {
 	err = process.Run()
 	if err != nil {
 		p.Environment.DisplayToConsole("Error running post execute, check daemon logs")
+		return
 	} 
 	
 	return

--- a/programs/program.go
+++ b/programs/program.go
@@ -95,11 +95,11 @@ func (p *ProgramData) Start() (err error) {
 		data[k] = v.Value
 	}
 
-	operationList := make([]ops.Operation, 0)
-	for _, element := range common.ToStringArray(p.RunData.Pre) {
-		operationList = append(operationList, &ops.Command{Command: common.ReplaceTokens(element, datamap), Environment: environment})
+	process := operations.GenerateProcess(p.RunData.Pre, p.Environment, p.DataToMap())
+	err = process.Run()
+	if err != nil {
+		p.Environment.DisplayToConsole("Error running pre execute, check daemon logs")
 	}
-	operations.OperationProcess{processInstructions: operationList}
 	
 	err = p.Environment.ExecuteAsync(p.RunData.Program, common.ReplaceTokensInArr(p.RunData.Arguments, data), func(graceful bool) {
 	})
@@ -121,6 +121,13 @@ func (p *ProgramData) Stop() (err error) {
 	} else {
 		p.Environment.DisplayToConsole("Server stopped\n")
 	}
+	
+	process := operations.GenerateProcess(p.RunData.Post, p.Environment, p.DataToMap())
+	err = process.Run()
+	if err != nil {
+		p.Environment.DisplayToConsole("Error running post execute, check daemon logs")
+	} 
+	
 	return
 }
 

--- a/programs/program.go
+++ b/programs/program.go
@@ -119,25 +119,9 @@ func (p *ProgramData) Stop() (err error) {
 	err = p.Environment.ExecuteInMainProcess(p.RunData.Stop)
 	if err != nil {
 		p.Environment.DisplayToConsole("Failed to stop server\n")
-		return
+	} else {
+		p.Environment.DisplayToConsole("Server stopped\n")
 	}
-	
-	// wait for 120 seconds while server stops
-	err = p.Environment.WaitForMainProcessFor(120)
-	if err != nil {
-		logging.Error("Error stopping server", err)
-		return
-	}
-	
-	p.Environment.DisplayToConsole("Server stopped\n")
-	
-	process := operations.GenerateProcess(p.RunData.Post, p.Environment, p.DataToMap())
-	err = process.Run()
-	if err != nil {
-		p.Environment.DisplayToConsole("Error running post execute, check daemon logs")
-		return
-	} 
-	
 	return
 }
 

--- a/programs/program.go
+++ b/programs/program.go
@@ -95,6 +95,12 @@ func (p *ProgramData) Start() (err error) {
 		data[k] = v.Value
 	}
 
+	operationList := make([]ops.Operation, 0)
+	for _, element := range common.ToStringArray(p.RunData.Pre) {
+		operationList = append(operationList, &ops.Command{Command: common.ReplaceTokens(element, datamap), Environment: environment})
+	}
+	operations.OperationProcess{processInstructions: operationList}
+	
 	err = p.Environment.ExecuteAsync(p.RunData.Program, common.ReplaceTokensInArr(p.RunData.Arguments, data), func(graceful bool) {
 	})
 	if err != nil {

--- a/programs/programdata.go
+++ b/programs/programdata.go
@@ -25,15 +25,15 @@ type DataObject struct {
 }
 
 type RunObject struct {
-	Arguments               []string `json:"arguments"`
-	Program                 string   `json:"program"`
-	Stop                    string   `json:"stop"`
-	Enabled                 bool     `json:"enabled"`
-	AutoStart               bool     `json:"autostart"`
-	AutoRestartFromCrash    bool     `json:"autorecover"`
-	AutoRestartFromGraceful bool     `json:"autorestart"`
-	Pre                     []string `json:"pre"`
-	Post                    []string `json:"post"`
+	Arguments               []string                 `json:"arguments"`
+	Program                 string                   `json:"program"`
+	Stop                    string                   `json:"stop"`
+	Enabled                 bool                     `json:"enabled"`
+	AutoStart               bool                     `json:"autostart"`
+	AutoRestartFromCrash    bool                     `json:"autorecover"`
+	AutoRestartFromGraceful bool                     `json:"autorestart"`
+	Pre                     []map[string]interface{} `json:"pre"`
+	Post                    []map[string]interface{} `json:"post"`
 }
 
 type InstallSection struct {

--- a/programs/programdata.go
+++ b/programs/programdata.go
@@ -32,6 +32,8 @@ type RunObject struct {
 	AutoStart               bool     `json:"autostart"`
 	AutoRestartFromCrash    bool     `json:"autorecover"`
 	AutoRestartFromGraceful bool     `json:"autorestart"`
+	Pre                     []string `json:"pre"`
+	Post                    []string `json:"post"`
 }
 
 type InstallSection struct {

--- a/programs/programdata.go
+++ b/programs/programdata.go
@@ -33,7 +33,6 @@ type RunObject struct {
 	AutoRestartFromCrash    bool                     `json:"autorecover"`
 	AutoRestartFromGraceful bool                     `json:"autorestart"`
 	Pre                     []map[string]interface{} `json:"pre"`
-	Post                    []map[string]interface{} `json:"post"`
 }
 
 type InstallSection struct {
@@ -55,6 +54,7 @@ func CreateProgram() ProgramData{
 		RunData: RunObject{
 			Enabled: true,
 			AutoStart: true,
+			Pre: make([]map[string]interface{}, 0),
 		},
 		Type: "standard",
 		Data: make(map[string]DataObject, 0),


### PR DESCRIPTION
Adding support for the pre block in the run object. This will not be an array of strings, as per the documentation, but an array of operations. This mimics the functions from the install section to run operations before the start of the sever.